### PR TITLE
Fix strip

### DIFF
--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -23,25 +23,20 @@ function! C_prototype#make() abort
 	" 配列(s:func_first)に格納
 	call C_prototype#assign()
 
-	" 一行ずつ貼り付け
-	let flag = 1
-	if getline(s:mainpos-1) != ''
-		call append(s:mainpos-1, '')
-		let flag = 0
-	endif
-	call cursor(s:mainpos - 1 - flag, 1)
-	" call cursor(s:mainpos, 1)
-	for content in s:func_first
-		" call append(line('.')-1, content)
-		call append(line('.'), content)
-		normal! j
+	let g:c_prototype_insert_point = get(g:, 'c_prototype_insert_point', 1)
+
+	let added_lines = s:func_first
+
+	" Add blank lines to line str list.
+	for i in range(0, g:c_prototype_insert_point - 1)
+		call add(added_lines, '')
 	endfor
-	unlet! flag
+
+	" Append prototypes.
+	call append(s:mainpos - 1, added_lines)
 
 	" ここでカーソルを元に戻す
 	call s:load_current_cursor()
-
-	unlet! content
 endfunction
 
 function! C_prototype#delete() abort

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -47,19 +47,25 @@ function! C_prototype#delete() abort
 	" プロトタイプ宣言探索
 	call C_prototype#get_proto()
 
+	if empty(s:proto_line) == 1
+		return
+	endif
+
 	" 一行ずつ消していく
 	let i = -1
 	for index in s:proto_line
 		let i += 1
 		execute index - i . 'delete'
 	endfor
-	if i != -1 && getline(s:proto_line[0]-1) == ''
-		execute s:proto_line[0] - 1 . 'delete'
+
+	let line_num = s:proto_line[0]
+	if getline(line_num) == ''
+		let g:c_prototype_insert_point = get(g:, 'c_prototype_insert_point', 1)
+		execute line_num . 'delete' . g:c_prototype_insert_point
 	endif
 
 	" ここでカーソルを元に戻す
 	call s:load_current_cursor()
-	unlet! i index
 endfunction
 
 function! C_prototype#declare() abort
@@ -182,7 +188,7 @@ endfunction
 function! C_prototype#assign() abort
 	let g:c_prototype_remove_var_name = get(g:, 'c_prototype_remove_var_name', 0)
 
-	let s:func_first = ['']
+	let s:func_first = []
 	for line_num in s:func_begin
 		let str = s:get_function_declare_line(line_num)
 		let str = substitute(str, '\s*{.*', '', 'g')

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -24,8 +24,6 @@ function! C_prototype#make() abort
 	call C_prototype#assign()
 
 	" 一行ずつ貼り付け
-	" ==================
-	" MODIFIED
 	let flag = 1
 	if getline(s:mainpos-1) != ''
 		call append(s:mainpos-1, '')
@@ -39,7 +37,6 @@ function! C_prototype#make() abort
 		normal! j
 	endfor
 	unlet! flag
-	" ==================
 
 	" ここでカーソルを元に戻す
 	call s:load_current_cursor()
@@ -162,11 +159,7 @@ endfunction
 function! C_prototype#get_protolist() abort
 	call add(s:now_proto, '')
 	for protoline in s:proto_line
-		" ==================
-		" MODIFIED
 		let tmp = getline(protoline)
-		" let tmp = substitute(getline(protoline), ';', '{', '')
-		" ==================
 		call add(s:now_proto, tmp)
 	endfor
 	unlet! protoline tmp
@@ -232,10 +225,7 @@ function! C_prototype#refresh() abort
 	if s:now_proto == s:func_first
 		echohl WarningMsg | echo 'No prototype declarations changed.' | echohl None
 	else
-		" ==================
-		" MODIFIED
 		call C_prototype#del()
-		" ==================
 		call C_prototype#declare()
 		call C_prototype#get_main()
 		call C_prototype#make()

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -192,12 +192,22 @@ function! C_prototype#get_lastpre() abort
 endfunction
 
 function! C_prototype#assign() abort
+	let g:c_prototype_remove_var_name = get(g:, 'c_prototype_remove_var_name', 0)
+
 	let s:func_first = ['']
 	for line_num in s:func_begin
 		let str = s:get_function_declare_line(line_num)
 		let str = substitute(str, '\s*{.*', '', 'g')
 		let str = matchstr(str, '\%([0-9a-zA-Z_*]\+\s\)\+\w\+(.*)') . ';'
-		if stridx(str, 'main') < 0
+
+		" If option is enable, remove function argument variables.
+		if g:c_prototype_remove_var_name == 1
+			if match(str, '(\s*void\s*)') == -1
+				let str = substitute(str, '\s*\w\+\s*\ze[,)]', '', 'g')
+			endif
+		endif
+
+		if stridx(str, 'main') == -1
 			call add(s:func_first, str)
 		endif
 	endfor

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -194,11 +194,11 @@ endfunction
 function! C_prototype#assign() abort
 	let s:func_first = ['']
 	for lineNum in s:func_begin
-		let addtxt = s:get_function_declare_line(lineNum)
-		let addtxt = matchstr(addtxt, '\%(;}\)\@<!\%(\w\+\s\+\)\+\%(\w\+(.*)\)\%(\s*{\)\@=') . ';'
-		let addtxt = substitute(addtxt , '\s*{.*', '', 'g')
-		if stridx(addtxt, 'main') < 0
-			call add(s:func_first, addtxt)
+		let str = s:get_function_declare_line(lineNum)
+		let str = substitute(str, '\s*{.*', '', 'g')
+		let str = matchstr(str, '\%([0-9a-zA-Z_*]\+\s\)\+\w\+(.*)') . ';'
+		if stridx(str, 'main') < 0
+			call add(s:func_first, str)
 		endif
 	endfor
 	unlet! lineNum

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -193,15 +193,14 @@ endfunction
 
 function! C_prototype#assign() abort
 	let s:func_first = ['']
-	for lineNum in s:func_begin
-		let str = s:get_function_declare_line(lineNum)
+	for line_num in s:func_begin
+		let str = s:get_function_declare_line(line_num)
 		let str = substitute(str, '\s*{.*', '', 'g')
 		let str = matchstr(str, '\%([0-9a-zA-Z_*]\+\s\)\+\w\+(.*)') . ';'
 		if stridx(str, 'main') < 0
 			call add(s:func_first, str)
 		endif
 	endfor
-	unlet! lineNum
 endfunction
 
 function! C_prototype#refresh() abort

--- a/autoload/C_prototype.vim
+++ b/autoload/C_prototype.vim
@@ -55,13 +55,13 @@ function! C_prototype#delete() abort
 	let i = -1
 	for index in s:proto_line
 		let i += 1
-		execute index - i . 'delete'
+		execute 'keepjumps ' . (index - i) . 'delete'
 	endfor
 
 	let line_num = s:proto_line[0]
 	if getline(line_num) == ''
 		let g:c_prototype_insert_point = get(g:, 'c_prototype_insert_point', 1)
-		execute line_num . 'delete' . g:c_prototype_insert_point
+		execute 'keepjumps ' . line_num . 'delete' . g:c_prototype_insert_point
 	endif
 
 	" ここでカーソルを元に戻す
@@ -85,7 +85,7 @@ endfunction
 
 " get系は実行前後にカーソル位置調整よろしく
 function! C_prototype#get_main() abort
-	let s:mainpos = search('.* *main *(.*)\s*\n*{')
+	let s:mainpos = search('.* *main *(.*)\s*\n*{', 'n')
 endfunction
 
 function! s:get_function_declare_line(line_number) abort
@@ -119,7 +119,7 @@ function! C_prototype#get_func() abort
 		endif
 	endif
 
-	normal! %
+	keepjumps normal! %
 	call add(s:func_end, line('.'))
 
 	" 2行目以降
@@ -133,17 +133,16 @@ function! C_prototype#get_func() abort
 		else
 			break
 		endif
-		normal! %
+		keepjumps normal! %
 		call add(s:func_end, line('.'))
 	endwhile
-	unlet! first tmp
 endfunction
 
 function! C_prototype#get_proto() abort
 	let s:proto_line = []
 	let prev = 0
 	while 1
-		let now = search('[^\s].* .*(.*) *;')
+		let now = search('[^\s].* .*(.*) *;', 'n')
 		if now > s:mainpos || now <= prev
 			break
 		endif
@@ -153,8 +152,9 @@ function! C_prototype#get_proto() abort
 		endif
 		call add(s:proto_line, now)
 		let prev = now
+
+		call cursor(now + 1, 1)
 	endwhile
-	unlet! prev now
 endfunction
 
 function! C_prototype#get_protolist() abort


### PR DESCRIPTION
以下の事項を修正/追加しました.
- プロトタイプ部の抜き取り修正
- プロトタイプの引数名削除オプション追加 (g:c_prototype_remove_var_name)
- プロトタイプ後に追加する空行をオプションに  (g:c_prototype_insert_point)
- ジャンプリストが変更されないように修正

プロトタイプの引数についてですが
引数を書かない場合、関数本体で引数名を変更した時にプロトタイプの修正がいらないので、引数なしも出来るようにしました
ジャンプリストについては、<C-I>と<C-O>での移動がコマンド実行後にうまくできなくなるので修正しました

よろしくお願いします
